### PR TITLE
Ensure the needed dependencies are selected and update the way `kraft up` is run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,49 @@
 # Unikraft C++ Hello World Application
 
-To build and run this application please use the `kraft` script:
+This application prints a basic "Hello World!" message.
 
-    pip3 install git+https://github.com/unikraft/kraft.git
-    mkdir my-first-unikernel && cd my-first-unikernel
-    kraft up -p PLATFORM -m ARCHITECTURE helloworld-cpp
+To configure, build and run the application you need to have [kraft](https://github.com/unikraft/kraft) installed.
+
+To be able to run it, configure the application to run on the desired platform and architecture:
+```
+$ kraft configure -p PLATFORM -m ARCH
+```
+
+Build the application:
+```
+$ kraft build
+```
+
+And, finally, run the application:
+```
+$ kraft run
+Hello World!
+```
+
+If you want to have more control you can also configure, build and run the application manually.
+
+To configure it with the desired features:
+```
+$ make menuconfig
+```
+
+Build the application:
+```
+$ make
+```
+
+Run the application:
+- If you built the application for `kvm`:
+```
+sudo qemu-system-x86_64 -kernel "build/app-helloworld-cpp_kvm-x86_64" \
+                        -enable-kvm \
+                        -nographic
+```
+
+- If you built the application for `linuxu`:
+```
+./build/app-helloworld-cpp_linuxu-x86_64
+```
 
 For more information about `kraft` type ```kraft -h``` or read the
 [documentation](http://docs.unikraft.org).

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -4,6 +4,11 @@ unikraft:
   version: '0.5'
   kconfig:
     - CONFIG_LIBPOSIX_SYSINFO=y
+    - CONFIG_LIBUKSIGNAL=y
+    - CONFIG_LIBNEWLIBC=y
+    - CONFIG_LIBCXXABI=y
+    - CONFIG_LIBCXX=y
+    - CONFIG_LIBUNWIND=y
 targets:
   - architecture: x86_64
     platform: linuxu


### PR DESCRIPTION
Some build time errors would sometimes occur as some of the dependencies would not actually be selected and in order to change that `kraft.yaml` has been updated. What is more, the way `kraft up` is run has also been updated as now the `-t` option seems to be mandatory.