### PR TITLE
Reorder external library in kraft.yaml file

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -6,7 +6,6 @@ unikraft:
   kconfig:
     - CONFIG_LIBPOSIX_SYSINFO=y
     - CONFIG_LIBUKSIGNAL=y
-    - CONFIG_LIBNEWLIBC=y
 targets:
   - architecture: x86_64
     platform: linuxu
@@ -17,13 +16,13 @@ targets:
   - architecture: arm64
     platform: kvm
 libraries:
-  libunwind:
+  musl:
     version: stable
-  compiler-rt:
+  libunwind:
     version: stable
   libcxx:
     version: stable
   libcxxabi:
     version: stable
-  musl:
+  compiler-rt:
     version: stable


### PR DESCRIPTION
With the current order of external libraries in the `kraft.yaml` file, the app won't build because `_LIBCPP_BEGIN_NAMESPACE_STD` is not defined. This is caused because `plat/kvm/x86/time.c` includes `stdlib.h` and since `libcxx` is placed before `musl`, the header is included from libcxx's origin code. This causes a problem because, when trying to compile `time.c` source, it will use the `stdlib.h` header from `libcxx` and not define the macro. Later on, when trying to parse the next header file that uses that define, it will stop the build process.
This PR reorders the external libraries in the correct order.

Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>