### PR TITLE
`kraft.yaml`: Fix contents

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -2,7 +2,7 @@
 specification: '0.5'
 name: helloworld-cpp
 unikraft:
-  version: staging
+  version: stable
   kconfig:
     - CONFIG_LIBPOSIX_SYSINFO=y
     - CONFIG_LIBUKSIGNAL=y
@@ -19,22 +19,22 @@ targets:
     platform: firecraker
 libraries:
   libcxxabi:
-    version: staging
+    version: stable
     kconfig:
       - CONFIG_LIBCXXABI=y
   libcxx:
-    version: staging
+    version: stable
     kconfig:
       - CONFIG_LIBCXX=y
   libunwind:
-    version: staging
+    version: stable
     kconfig:
       - CONFIG_LIBUNWIND=y
   compiler-rt:
-    version: staging
+    version: stable
     kconfig:
       - CONFIG_LIBCOMPILER_RT=y
   musl:
-    version: staging
+    version: stable
     kconfig:
       - CONFIG_LIBMUSL=y

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -16,7 +16,7 @@ targets:
   - architecture: arm64
     platform: qemu
   - architecture: x86_64
-    platform: firecraker
+    platform: firecracker
 libraries:
   libcxxabi:
     version: stable


### PR DESCRIPTION
Use `stable` version throughout `kraft.yaml` for all components. Also fix a typo to allow a Kraftkit-based build.